### PR TITLE
Allow region to be interpolated into Slack message

### DIFF
--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -1,48 +1,73 @@
 /* eslint-disable no-undef */
-const SlackServerlessPlugin = require('../index');
+const SlackServerlessPlugin = require("../index");
 
-describe('serverless plugin slack', () => {
-  test('it fails on absent config ', () => {
-    const config = { service: { custom: {} } };
+describe("serverless plugin slack", () => {
+  const defaultProvider = { name: "aws", region: "us-east-2" };
 
-    expect(() => { new SlackServerlessPlugin(config); }).toThrow('No Slack options set in config');
+  test("it fails on absent config ", () => {
+    const config = { service: { custom: {} }, provider: defaultProvider };
+
+    expect(() => {
+      new SlackServerlessPlugin(config);
+    }).toThrow("No Slack options set in config");
   });
 
-  test('it fails on absent webhook url ', () => {
-    const config = { service: { custom: { slack: {} } } };
+  test("it fails on absent webhook url ", () => {
+    const config = {
+      service: { custom: { slack: {} } },
+      provider: defaultProvider
+    };
 
-    expect(() => { new SlackServerlessPlugin(config); }).toThrow('No Slack webhook url set in config');
+    expect(() => {
+      new SlackServerlessPlugin(config);
+    }).toThrow("No Slack webhook url set in config");
   });
 
-  test('sends an emoji when defined', () => {
-      const config = { service: { service: 'foobar', custom: { slack: { emoji: ':cloud:', user: 'jd', webhook_url: 'https://example.com' } } } };
-      const options = { f: 'bar', stage: 'staging' };
+  test("sends an emoji when defined", () => {
+    const config = {
+      service: {
+        service: "foobar",
+        custom: {
+          slack: {
+            emoji: ":cloud:",
+            user: "jd",
+            webhook_url: "https://example.com"
+          }
+        }
+      },
+      provider: defaultProvider
+    };
+    const options = { f: "bar", stage: "staging" };
 
-      const plugin = new SlackServerlessPlugin(config, options);
+    const plugin = new SlackServerlessPlugin(config, options);
 
-      SlackServerlessPlugin.sendWebhook = jest.fn();
+    SlackServerlessPlugin.sendWebhook = jest.fn();
 
-      plugin.afterDeployService();
+    plugin.afterDeployService();
 
-      expect(SlackServerlessPlugin.sendWebhook).toHaveBeenCalledWith({
-        body: '{\"text\":\"`jd` deployed service `foobar` to environment `staging`\",\"username\":\"jd\",\"icon_emoji\":\":cloud:\"}',
-        headers: { 'Content-type': 'application/json' },
-        method: 'POST',
-        url: 'https://example.com',
-      });
+    expect(SlackServerlessPlugin.sendWebhook).toHaveBeenCalledWith({
+      body:
+        '{"text":"`jd` deployed service `foobar` to environment `staging`","username":"jd","icon_emoji":":cloud:"}',
+      headers: { "Content-type": "application/json" },
+      method: "POST",
+      url: "https://example.com"
+    });
   });
 
   describe("reportable", () => {
     test("does not report to non-reportable environments", () => {
       const slack = {
-        user: 'jd',
-        webhook_url: 'some-uri',
+        user: "jd",
+        webhook_url: "some-uri",
         reportable: {
-          stages: ['dev']
+          stages: ["dev"]
         }
       };
-      const config = { service: { service: 'foobar', custom: { slack } } };
-      const options = { f: 'bar', stage: 'ci' };
+      const config = {
+        service: { service: "foobar", custom: { slack } },
+        provider: defaultProvider
+      };
+      const options = { f: "bar", stage: "ci" };
 
       const plugin = new SlackServerlessPlugin(config, options);
 
@@ -54,10 +79,16 @@ describe('serverless plugin slack', () => {
     });
   });
 
-  describe('single function deployment', () => {
-    test('it sends message', () => {
-      const config = { service: { service: 'foobar', custom: { slack: { user: 'jd', webhook_url: 'https://example.com' } } } };
-      const options = { f: 'bar', stage: 'staging' };
+  describe("single function deployment", () => {
+    test("it sends message", () => {
+      const config = {
+        service: {
+          service: "foobar",
+          custom: { slack: { user: "jd", webhook_url: "https://example.com" } }
+        },
+        provider: defaultProvider
+      };
+      const options = { f: "bar", stage: "staging" };
 
       const plugin = new SlackServerlessPlugin(config, options);
 
@@ -66,18 +97,25 @@ describe('serverless plugin slack', () => {
       plugin.afterDeployFunction();
 
       expect(SlackServerlessPlugin.sendWebhook).toHaveBeenCalledWith({
-        body: '{\"text\":\"`jd` deployed function `bar` to environment `staging` in service `foobar`\",\"username\":\"jd\"}',
-        headers: { 'Content-type': 'application/json' },
-        method: 'POST',
-        url: 'https://example.com',
+        body:
+          '{"text":"`jd` deployed function `bar` to environment `staging` in service `foobar`","username":"jd"}',
+        headers: { "Content-type": "application/json" },
+        method: "POST",
+        url: "https://example.com"
       });
     });
   });
 
-  describe('service deployment', () => {
-    test('it sends message', () => {
-      const config = { service: { service: 'foobar', custom: { slack: { user: 'jd', webhook_url: 'https://example.com' } } } };
-      const options = { f: 'bar', stage: 'staging' };
+  describe("service deployment", () => {
+    test("it sends message", () => {
+      const config = {
+        service: {
+          service: "foobar",
+          custom: { slack: { user: "jd", webhook_url: "https://example.com" } }
+        },
+        provider: defaultProvider
+      };
+      const options = { f: "bar", stage: "staging" };
 
       const plugin = new SlackServerlessPlugin(config, options);
 
@@ -86,18 +124,24 @@ describe('serverless plugin slack', () => {
       plugin.afterDeployService();
 
       expect(SlackServerlessPlugin.sendWebhook).toHaveBeenCalledWith({
-        body: '{\"text\":\"`jd` deployed service `foobar` to environment `staging`\",\"username\":\"jd\"}',
-        headers: { 'Content-type': 'application/json' },
-        method: 'POST',
-        url: 'https://example.com',
+        body:
+          '{"text":"`jd` deployed service `foobar` to environment `staging`","username":"jd"}',
+        headers: { "Content-type": "application/json" },
+        method: "POST",
+        url: "https://example.com"
       });
     });
-  });
 
-  describe('default parameters properly', () => {
-    test('it sends message', () => {
-      const config = { service: { service: 'foobar', custom: { slack: { user: 'jd', webhook_url: 'https://example.com' } } } };
-      const options = { f: 'bar' };
+    test("it sends message with region", () => {
+      const config = {
+        service: {
+          service: "foobar",
+          custom: { slack: { user: "jd", webhook_url: "https://example.com" } }
+        },
+        provider: defaultProvider
+      };
+
+      const options = { f: "bar", stage: "staging" };
 
       const plugin = new SlackServerlessPlugin(config, options);
 
@@ -106,30 +150,60 @@ describe('serverless plugin slack', () => {
       plugin.afterDeployService();
 
       expect(SlackServerlessPlugin.sendWebhook).toHaveBeenCalledWith({
-        body: '{\"text\":\"`jd` deployed service `foobar` to environment `dev`\",\"username\":\"jd\"}',
-        headers: { 'Content-type': 'application/json' },
-        method: 'POST',
-        url: 'https://example.com',
+        body:
+          '{"text":"`jd` deployed service `foobar` to environment `staging`","username":"jd"}',
+        headers: { "Content-type": "application/json" },
+        method: "POST",
+        url: "https://example.com"
       });
     });
   });
 
-  describe('environment variables', () => {
-    test('Uses process.env.GIT_SHA in the message', () => {
-      process.env.GIT_SHA = 'deadbeef';
+  describe("default parameters properly", () => {
+    test("it sends message", () => {
+      const config = {
+        service: {
+          service: "foobar",
+          custom: { slack: { user: "jd", webhook_url: "https://example.com" } }
+        },
+        provider: defaultProvider
+      };
+      const options = { f: "bar" };
+
+      const plugin = new SlackServerlessPlugin(config, options);
+
+      SlackServerlessPlugin.sendWebhook = jest.fn();
+
+      plugin.afterDeployService();
+
+      expect(SlackServerlessPlugin.sendWebhook).toHaveBeenCalledWith({
+        body:
+          '{"text":"`jd` deployed service `foobar` to environment `dev`","username":"jd"}',
+        headers: { "Content-type": "application/json" },
+        method: "POST",
+        url: "https://example.com"
+      });
+    });
+  });
+
+  describe("environment variables", () => {
+    test("Uses process.env.GIT_SHA in the message", () => {
+      process.env.GIT_SHA = "deadbeef";
+      process.env.USER = process.env.DEPLOYER = "admin";
 
       const config = {
         service: {
-          service: 'foobar',
+          service: "foobar",
           custom: {
             slack: {
-              service_deploy_message: 'git sha: {{GIT_SHA}}',
-              webhook_url: 'https://example.com',
-            },
-          },
+              service_deploy_message: "git sha: {{GIT_SHA}}",
+              webhook_url: "https://example.com"
+            }
+          }
         },
+        provider: defaultProvider
       };
-      const options = { f: 'bar' };
+      const options = { f: "bar" };
 
       const plugin = new SlackServerlessPlugin(config, options);
 
@@ -139,19 +213,25 @@ describe('serverless plugin slack', () => {
 
       expect(SlackServerlessPlugin.sendWebhook).toHaveBeenCalledWith({
         body: JSON.stringify({
-          text: 'git sha: deadbeef',
-          username: 'admin',
+          text: "git sha: deadbeef",
+          username: "admin"
         }),
-        headers: { 'Content-type': 'application/json' },
-        method: 'POST',
-        url: 'https://example.com',
+        headers: { "Content-type": "application/json" },
+        method: "POST",
+        url: "https://example.com"
       });
     });
 
     test("Can set the user from process.env.DEPLOYER", () => {
       process.env.DEPLOYER = "imadeployer";
-      const config = { service: { service: 'foobar', custom: { slack: { webhook_url: 'https://example.com' } } } };
-      const options = { f: 'bar' };
+      const config = {
+        service: {
+          service: "foobar",
+          custom: { slack: { webhook_url: "https://example.com" } }
+        },
+        provider: defaultProvider
+      };
+      const options = { f: "bar" };
 
       const plugin = new SlackServerlessPlugin(config, options);
 
@@ -160,10 +240,11 @@ describe('serverless plugin slack', () => {
       plugin.afterDeployService();
 
       expect(SlackServerlessPlugin.sendWebhook).toHaveBeenCalledWith({
-        body: '{\"text\":\"`imadeployer` deployed service `foobar` to environment `dev`\",\"username\":\"imadeployer\"}',
-        headers: { 'Content-type': 'application/json' },
-        method: 'POST',
-        url: 'https://example.com',
+        body:
+          '{"text":"`imadeployer` deployed service `foobar` to environment `dev`","username":"imadeployer"}',
+        headers: { "Content-type": "application/json" },
+        method: "POST",
+        url: "https://example.com"
       });
     });
   });


### PR DESCRIPTION
We are running global deployments and deploy region-by-region so I wanted to present the current region in the slack message.

Sorry for the "extra" diff –– prettier is set to run automatically. If it's bothersome, I can disable prettier and redo the PR.